### PR TITLE
Change mellanox/accelerated-bridge-cni image version

### DIFF
--- a/images/k8s-v1.10-v1.15/accelerated-bridge-cni-daemonset.yaml
+++ b/images/k8s-v1.10-v1.15/accelerated-bridge-cni-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-accelerated-bridge-cni
-        image: mellanox/accelerated-bridge-cni:v2.3
+        image: mellanox/accelerated-bridge-cni:v0.1.0
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/images/k8s-v1.16/accelerated-bridge-cni-daemonset.yaml
+++ b/images/k8s-v1.16/accelerated-bridge-cni-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-accelerated-bridge-cni
-        image: mellanox/accelerated-bridge-cni:v2.3
+        image: mellanox/accelerated-bridge-cni:v0.1.0
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
Change mellanox/accelerated-bridge-cni image version

Replace v2.3 with v0.1.0
v2.3 image version is a leftover from sriov-cni.
Accelerated bridge CNI has no v2.3, first version
will be v0.1.0.