### PR TITLE
Remove unused functions from manager and utils packages

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -10,11 +10,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/k8snetworkplumbingwg/accelerated-bridge-cni/pkg/types"
-	"github.com/k8snetworkplumbingwg/accelerated-bridge-cni/pkg/utils"
-)
-
-const (
-	ON = "on"
 )
 
 // mocked netlink interface
@@ -117,26 +112,6 @@ func bridgeTrunkVlanAdd(nlink NetlinkManager, link netlink.Link, vlans []int) er
 	return nil
 }
 
-type pciUtils interface {
-	getSriovNumVfs(ifName string) (int, error)
-	getVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error)
-	getPciAddress(ifName string, vf int) (string, error)
-}
-
-type pciUtilsImpl struct{}
-
-func (p *pciUtilsImpl) getSriovNumVfs(ifName string) (int, error) {
-	return utils.GetSriovNumVfs(ifName)
-}
-
-func (p *pciUtilsImpl) getVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error) {
-	return utils.GetVFLinkNamesFromVFID(pfName, vfID)
-}
-
-func (p *pciUtilsImpl) getPciAddress(ifName string, vf int) (string, error) {
-	return utils.GetPciAddress(ifName, vf)
-}
-
 // mocked sriovnet interface
 // required for unit tests
 
@@ -162,7 +137,6 @@ type Manager interface {
 
 type manager struct {
 	nLink NetlinkManager
-	utils pciUtils
 	sriov Sriovnet
 }
 
@@ -170,7 +144,6 @@ type manager struct {
 func NewManager() Manager {
 	return &manager{
 		nLink: &MyNetlink{},
-		utils: &pciUtilsImpl{},
 		sriov: &MyLittleSriov{},
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -89,28 +89,6 @@ func GetPfName(vf string) (string, error) {
 	return strings.TrimSpace(files[0].Name()), nil
 }
 
-// GetPciAddress takes in a interface(ifName) and VF id and returns returns its pci addr as string
-func GetPciAddress(ifName string, vf int) (string, error) {
-	var pciaddr string
-	vfDir := filepath.Join(NetDirectory, ifName, "device", fmt.Sprintf("virtfn%d", vf))
-	dirInfo, err := os.Lstat(vfDir)
-	if err != nil {
-		return pciaddr, fmt.Errorf("can't get the symbolic link of virtfn%d dir of the device %q: %v", vf, ifName, err)
-	}
-
-	if (dirInfo.Mode() & os.ModeSymlink) == 0 {
-		return pciaddr, fmt.Errorf("no symbolic link for the virtfn%d dir of the device %q", vf, ifName)
-	}
-
-	pciinfo, err := os.Readlink(vfDir)
-	if err != nil {
-		return pciaddr, fmt.Errorf("can't read the symbolic link of virtfn%d dir of the device %q: %v", vf, ifName, err)
-	}
-
-	pciaddr = filepath.Base(pciinfo)
-	return pciaddr, nil
-}
-
 // GetVFLinkName returns VF's network interface name given it's PCI addr
 func GetVFLinkName(pciAddr string) (string, error) {
 	vfDir := filepath.Join(SysBusPci, pciAddr, "net")
@@ -133,26 +111,6 @@ func GetVFLinkName(pciAddr string) (string, error) {
 	}
 
 	return names[0], nil
-}
-
-// GetVFLinkNamesFromVFID returns VF's network interface name given it's PF name as string and VF id as int
-func GetVFLinkNamesFromVFID(pfName string, vfID int) ([]string, error) {
-	vfDir := filepath.Join(NetDirectory, pfName, "device", fmt.Sprintf("virtfn%d", vfID), "net")
-	if _, err := os.Lstat(vfDir); err != nil {
-		return nil, err
-	}
-
-	fInfos, err := ioutil.ReadDir(vfDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the virtfn%d dir of the device %q: %v", vfID, pfName, err)
-	}
-
-	names := make([]string, 0, len(fInfos))
-	for _, f := range fInfos {
-		names = append(names, f.Name())
-	}
-
-	return names, nil
 }
 
 // SaveNetConf takes in container ID, data dir and Pod interface name as string and Conf as []byte

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -41,30 +41,4 @@ var _ = Describe("Utils", func() {
 			Expect(err).To(HaveOccurred(), "Not existing VF should return an error")
 		})
 	})
-	Context("Checking GetPciAddress function", func() {
-		It("Assuming existing interface and vf", func() {
-			Expect(GetPciAddress("enp175s0f1", 0)).To(Equal("0000:af:06.0"),
-				"Existing PF and VF id should return correct VF pci address")
-		})
-		It("Assuming not existing interface", func() {
-			_, err := GetPciAddress("enp175s0f2", 0)
-			Expect(err).To(HaveOccurred(), "Not existing PF should return an error")
-		})
-		It("Assuming not existing vf", func() {
-			result, err := GetPciAddress("enp175s0f1", 33)
-			Expect(result).To(Equal(""), "Not existing VF id should not return pci address")
-			Expect(err).To(HaveOccurred(), "Not existing VF id should return an error")
-		})
-	})
-	Context("Checking GetVFLinkNames function", func() {
-		It("Assuming existing vf", func() {
-			result, err := GetVFLinkNamesFromVFID("enp175s0f1", 0)
-			Expect(result).To(ContainElement("enp175s6"), "Existing PF should have at least one VF")
-			Expect(err).NotTo(HaveOccurred(), "Existing PF should not return an error")
-		})
-		It("Assuming not existing vf", func() {
-			_, err := GetVFLinkNamesFromVFID("enp175s0f1", 3)
-			Expect(err).To(HaveOccurred(), "Not existing VF should return an error")
-		})
-	})
 })


### PR DESCRIPTION
This commit removes unused field "utils" from
the manager struct.
pciUtils interface and pciUtilsImpls struct
from manager package were also removed,
because they don't used anymore

GetPciAddress, GetVFLinkNamesFromVFID from
utils package were used only by pciUtilsImpls,
so they also removed
