### PR TITLE
Refactoring plugin package

### DIFF
--- a/pkg/plugin/cmdcontext.go
+++ b/pkg/plugin/cmdcontext.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+
+	localtypes "github.com/k8snetworkplumbingwg/accelerated-bridge-cni/pkg/types"
+)
+
+// cmdContext struct holds context of the current command call
+type cmdContext struct {
+	args       *skel.CmdArgs
+	pluginConf *localtypes.PluginConf
+
+	netNS  ns.NetNS
+	result *current.Result
+
+	errorHandlers []func()
+}
+
+// add register cleanup function which should be called if cmd completed with error
+func (cmd *cmdContext) registerErrorHandler(f func()) {
+	cmd.errorHandlers = append(cmd.errorHandlers, f)
+}
+
+// run registered clean up functions if command completed with error
+func (cmd *cmdContext) handleError(err error) {
+	if err != nil {
+		for i := len(cmd.errorHandlers) - 1; i >= 0; i-- {
+			cmd.errorHandlers[i]()
+		}
+	}
+}

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -1,0 +1,20 @@
+package plugin
+
+import "github.com/containernetworking/cni/pkg/types"
+
+type envArgs struct {
+	types.CommonArgs
+	MAC types.UnmarshallableString `json:"mac,omitempty"`
+}
+
+func getEnvArgs(envArgsString string) (*envArgs, error) {
+	if envArgsString != "" {
+		e := envArgs{}
+		err := types.LoadArgs(envArgsString, &e)
+		if err != nil {
+			return nil, err
+		}
+		return &e, nil
+	}
+	return nil, nil
+}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Plugin - test CNI command flows", func() {
 		successfullyGetNS := func() {
 			successfullyParseConfig()
 			nsMock.On("GetNS", testValidNSPath).Return(netNSMock, nil).Once()
+			netNSMock.On("Path").Return(testValidNSPath).Once()
 		}
 		successfullyAttachRepresentor := func() {
 			successfullyGetNS()
@@ -148,7 +149,6 @@ var _ = Describe("Plugin - test CNI command flows", func() {
 		successfullyApplyVFConfig := func() {
 			successfullyAttachRepresentor()
 			managerMock.On("ApplyVFConfig", pluginConf).Return(nil).Once()
-			netNSMock.On("Path").Return(testValidNSPath).Once()
 		}
 		successfullySetupVF := func() {
 			successfullyApplyVFConfig()


### PR DESCRIPTION
Split CmdAdd function to multiple smaller functions.

Add cmdContext struct to easily path parameters
between functions in CmdAdd flow.

Also cmdContext provide API to register error handlers
which will be called if CmdAdd flow completed with error.

Is a part of solving #7