### PR TITLE
Enable funlen and gocognit linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters-settings:
   gocognit:
     min-complexity: 30
   goimports:
-    local-prefixes: github.com/Mellanox/ib-sriov-cni
+    local-prefixes: github.com/k8snetworkplumbingwg/accelerated-bridge-cni
   golint:
     min-confidence: 0
   gomnd:
@@ -60,11 +60,11 @@ linters:
     - dogsled
     - dupl
     - errcheck
-      #- funlen # FIXME main.go:cmdAdd & manager.go:ApplyVFConfig
+    - funlen
     - gochecknoinits
     - goconst
     - gocritic
-      #- gocognit # FIXME config.go:LoadConf
+    - gocognit
     - gofmt
     - goimports
     - golint


### PR DESCRIPTION
Complex functions were refactored.

Closes: #7 

Linters should pass after merge of: #35 and #36