### PR TITLE
Add support for VFs which use userspace drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ A metaplugin such as [Multus](https://github.com/intel/multus-cni) gets the allo
 
 Accelerated Bridge plugin assumes that Linux Bridge is already exist and correctly configured on nodes.
 
+CNI plugin also supports VF bound to userspace driver (currently only vfio-pci) which may be utilized
+for virtualization use-case i.e [KubeVirt](https://github.com/kubevirt/kubevirt).
+If CNI plugin detects that VF bounded to a userspace driver, it will skip step with VF netdev configuration.
+
 ## Build
 
 This plugin uses Go modules for dependency management and requires Go 1.13+ to build.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,6 +42,8 @@ type NetConf struct {
 // PluginConf is a internal representation of config options and state
 type PluginConf struct {
 	NetConf
+	// IsUserspaceDriver indicate that VF using userspace driver
+	IsUserspaceDriver bool
 	// Stores the original VF state as it was prior to any operations done during cmdAdd flow
 	OrigVfState VfState `json:"orig_vf_state"`
 	// Name of the PF to which VF belongs

--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -36,6 +36,10 @@ var ts = tmpSysFs{
 		"sys/devices/pci0000:ae/0000:ae:00.0/0000:af:06.1/net/enp175s7",
 		"sys/devices/pci0000:00/0000:00:02.0/0000:05:00.0/net/ens1",
 		"sys/devices/pci0000:00/0000:00:02.0/0000:05:00.0/net/ens1d1",
+		"sys/bus/pci/devices/0000:11:00.0",
+		"sys/bus/pci/devices/0000:12:00.0",
+		"sys/bus/pci/drivers/mlx5_core",
+		"sys/bus/pci/drivers/vfio-pci",
 	},
 	fileList: map[string][]byte{
 		"sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.1/sriov_numvfs": []byte("2"),
@@ -66,6 +70,8 @@ var ts = tmpSysFs{
 
 		"sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.1/virtfn1": "sys/devices/pci0000:ae/0000:ae:00.0/0000:af:06.1",
 		"sys/devices/pci0000:ae/0000:ae:00.0/0000:af:06.1/physfn":  "sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.1",
+		"sys/bus/pci/devices/0000:11:00.0/driver":                  "sys/bus/pci/drivers/vfio-pci",
+		"sys/bus/pci/devices/0000:12:00.0/driver":                  "sys/bus/pci/drivers/mlx5_core",
 	},
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -41,4 +41,16 @@ var _ = Describe("Utils", func() {
 			Expect(err).To(HaveOccurred(), "Not existing VF should return an error")
 		})
 	})
+	Context("Checking HasUserspaceDriver function", func() {
+		It("Use userspace driver", func() {
+			result, err := HasUserspaceDriver("0000:11:00.0")
+			Expect(err).NotTo(HaveOccurred(), "HasUserspaceDriver should not return an error")
+			Expect(result).To(BeTrue(), "HasUserspaceDriver should return true")
+		})
+		It("Has not userspace driver", func() {
+			result, err := HasUserspaceDriver("0000:12:00.0")
+			Expect(result).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred(), "HasUserspaceDriver should not return an error")
+		})
+	})
 })


### PR DESCRIPTION
Now accelerated-bridge-cni supports VF bound to userspace
driver (currently only vfio-pci) which may be utilized
for virtualization use-case i.e kubevirt.
If CNI plugin detects that VF bounded to a userspace
driver, it will skip step with VF netdev configuration.