### PR TITLE
Add git package installation to builder image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
 WORKDIR /usr/src/accelerated-bridge-cni
-RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 && \
+RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 git && \
     make clean && \
     make build
 


### PR DESCRIPTION
Now project builds with go1.18.
Be default, go1.18 tries to stamp binaries with version control
information. This requires VCS binary to exist.

New default go tool behavior can be disabled by "-buildvcs" build flag, but I prefer to keep it enabled, it can be nice to have VCS info in binary for debugability.

Will fix this [CI failure](https://github.com/k8snetworkplumbingwg/accelerated-bridge-cni/runs/5649263915?check_suite_focus=true)
