### PR TITLE
Save original VF's MAC to restore it later if custom MAC was configured

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -177,6 +177,8 @@ func (m *manager) ApplyVFConfig(conf *types.PluginConf) error {
 		return fmt.Errorf("failed to find vf %d", conf.VFID)
 	}
 
+	conf.OrigVfState.AdminMAC = vfState.Mac.String() // Save administrative MAC for restoring it later
+
 	// Set mac address
 	if conf.MAC != "" {
 		var hwaddr net.HardwareAddr


### PR DESCRIPTION
If network attachment is configured to set the custom MAC, the cni tries to restore the original MAC of the VF when resetting its state on cleanup.
Previously, the administrative MAC adress (VF's MAC) was not saved prior to changing it to a custom address.
This led to the pod/vm that used the network, being frozen on deletion.
To fix the issue, persisting the original MAC on VF setup

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>