### PR TITLE
Update DeviceInfo in CNIDeviceInfoFile with PCI dev details

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ spec:
   "type": "accelerated-bridge",
   "cniVersion": "0.3.1",
   "name": "some-net",
+  "capabilities": {"CNIDeviceInfoFile": true},
   "ipam": {
     "type": "host-local",
     "subnet": "10.56.217.0/24",
@@ -93,6 +94,10 @@ spec:
 ```
 
 The `.spec.config` field contains the configuration information used by the Accelerated Bridge CNI.
+
+_Note: `"capabilities": {"CNIDeviceInfoFile": true}` is required if you want Multus to pass on
+[DeviceInfo file](https://github.com/k8snetworkplumbingwg/device-info-spec/blob/main/SPEC.md#4-device-information-files) 
+to the plugin. Accelerated Bridge plugin will add additional PCI device information to the file if the file is provided._
 
 ### Basic configuration parameters
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -46,7 +46,8 @@ type NetConf struct {
 	// PCI address of a VF in valid sysfs format
 	DeviceID      string `json:"deviceID"`
 	RuntimeConfig struct {
-		Mac string `json:"mac,omitempty"`
+		Mac               string `json:"mac,omitempty"`
+		CNIDeviceInfoFile string `json:"CNIDeviceInfoFile,omitempty"`
 	} `json:"runtimeConfig,omitempty"`
 }
 


### PR DESCRIPTION
Update DeviceInfo in CNIDeviceInfoFile with PCI dev details

This will happen only if runtimeConfig.CNIDeviceInfoFile parameter
passed to CNI.

The plugin will automatically update DeviceInfo file to 1.1.0
version if the file has 1.0.0 version.

If plugin failed to update the file it will log error and proceed.

The plugin will set "representor-device" field.