### PR TITLE
Replace ioutil.TempDir with os.MkdirTemp functions in tests

### DIFF
--- a/pkg/utils/testing.go
+++ b/pkg/utils/testing.go
@@ -7,7 +7,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -78,7 +77,7 @@ var ts = tmpSysFs{
 // CreateTmpSysFs create mock sysfs for testing
 // nolint:gosec
 func CreateTmpSysFs() error {
-	tmpdir, err := ioutil.TempDir("/tmp", "accelerated-bridge-testfiles-")
+	tmpdir, err := os.MkdirTemp("/tmp", "accelerated-bridge-testfiles-")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
ioutil.TempDir is Deprecated: As of Go 1.17,
this function simply calls os.MkdirTemp.

Without this change linter check will fail.

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>