### PR TITLE
Return success if plugin config is not found in CmdDel

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -247,7 +247,15 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 	pluginConf := &localtypes.PluginConf{}
 	err = p.cache.Load(pRef, pluginConf)
 	if err != nil {
-		return err
+		// If cmdDel() fails, cached netconf is cleaned up by
+		// the followed defer call or might not exist in the first place.
+		// However, subsequence calls of cmdDel()
+		// from container runtime fail in a dead loop because
+		// the cached netconf doesn't exist.
+		// Return nil when cache.Load() fails since the rest
+		// of cmdDel() code relies on netconf as input argument
+		// and there is no meaning to continue.
+		return nil
 	}
 
 	if pluginConf.Debug {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -402,7 +402,7 @@ var _ = Describe("Plugin - test CNI command flows", func() {
 					Return(testValidCacheRef).Once()
 				cacheMock.On("Load", testValidCacheRef, mock.Anything).
 					Return(errTest).Once()
-				Expect(plugin.CmdDel(cmdArgs)).To(HaveOccurred())
+				Expect(plugin.CmdDel(cmdArgs)).ToNot(HaveOccurred())
 			})
 			It("Failed to call IPAM del", func() {
 				successfullyDetachRepresentor()


### PR DESCRIPTION
Introduced in https://github.com/containerd/containerd/pull/5904, containerd now calls CmdDel for a pod indefinitely until it succeeds.

If cmdDel() fails, cached netconf is cleaned up by the followed defer call or might not exist in the first place. So, subsequence calls of cmdDel() from container runtime fail in a dead loop because the cached netconf doesn't exist.
Return nil when cache.Load() fails since the rest of cmdDel() code relies on netconf as input argument and there is no meaning to continue.

Signed-off-by: amaslennikov <amaslennikov@nvidia.com>