### PR TITLE
bump golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,6 @@ linters-settings:
     min-complexity: 30
   goimports:
     local-prefixes: github.com/k8snetworkplumbingwg/accelerated-bridge-cni
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
@@ -55,7 +53,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -79,13 +76,11 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GOLANGCI_LINT   = $(BINDIR)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.46.2
+GOLANGCI_LINT_VER = v1.51.2
 TIMEOUT         = 15
 V               = 0
 Q               = $(if $(filter 1,$V),,@)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -219,6 +219,9 @@ func (p *Plugin) updateDeviceInfo(cmdCtx *cmdContext) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal DeviceInfo to JSON %q", err)
 	}
+	//nolint:gosec
+	// save with same permissions as https://github.com/k8snetworkplumbingwg/network-attachment-definition-client
+	// utils.saveDeviceInfo
 	err = os.WriteFile(cmdCtx.pluginConf.RuntimeConfig.CNIDeviceInfoFile, bytes, 0444)
 	if err != nil {
 		return fmt.Errorf("failed to update CNIDeviceInfoFile %q", err)


### PR DESCRIPTION
typecheck linter does not play nice with go 1.20[1] bump golangci-lint version to 1.51.2

[1] https://github.com/golangci/golangci-lint/issues/3420